### PR TITLE
Improve compatibility

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -15,11 +15,14 @@ buildscript {
     }
 }
 
+
+
 group = 'de.measite.minidns'
 description = "A minimal DNS client library with support for A, AAAA, NS and SRV records"
 sourceCompatibility = 1.7
+targetCompatibility = 1.7
 version = 'git tag --points-at HEAD'.execute().text.trim()
-isSNAPSHOT = 'git rev-parse --abbrev-ref HEAD'.execute().text.trim() == 'master'
+def isSNAPSHOT = 'git rev-parse --abbrev-ref HEAD'.execute().text.trim() == 'master'
 
 if (isSNAPSHOT) {
   version = version + '-SNAPSHOT'


### PR DESCRIPTION
the def is needed because otherwise:

> No such property: isSNAPSHOT for class: org.gradle.api.internal.project.DefaultProject_Decorated

the target-compatibility helps to use the lib with android - background: https://github.com/open-keychain/minidns/pull/1
